### PR TITLE
Visit cancellation

### DIFF
--- a/client/src/actions/types.js
+++ b/client/src/actions/types.js
@@ -55,6 +55,7 @@ export const USERS_LOADING = 'USERS_LOADING'
 export const FILTER_VISITS = 'FILTER_VISITS'
 export const GET_VISITS = 'GET_VISITS';
 export const INIT_VISITS = 'INIT_VISITS'
+export const CANCEL_VISIT = 'CANCEL_VISIT'
 export const DELETE_VISIT = 'DELETE_VISIT';
 export const ADD_VISIT = 'ADD_VISIT'
 export const UPDATE_VISIT = 'UPDATE_VISIT'

--- a/client/src/actions/visitActions.js
+++ b/client/src/actions/visitActions.js
@@ -7,6 +7,7 @@ import {
     UPDATE_VISIT,
     SAVING_VISIT,
     SAVING_VISIT_CANCEL,
+    CANCEL_VISIT,
     DELETE_VISIT,
     VISITS_LOADING
  } from './types';
@@ -64,6 +65,20 @@ export const initVisits = (dispatch, getState) => {
         type: INIT_VISITS,
         payload: user ? '/api/users/' + user + '/visits' : null
     })
+}
+
+export const cancelVisit = id => (dispatch, getState) => {
+    axios
+        .post(`/api/visits/cancelled/${id}`,{},tokenConfig(getState))
+        .then(res => {
+            dispatch({
+                type: CANCEL_VISIT,
+                payload: id
+            })
+        })
+        .catch(err => {
+            dispatch(returnErrors(err.response.data,err.response.status));
+        })
 }
 
 export const deleteVisit = id => (dispatch, getState) => {

--- a/client/src/components/advisories/AdvisoryEditor.js
+++ b/client/src/components/advisories/AdvisoryEditor.js
@@ -267,7 +267,7 @@ export default function AdvisoryEditor({advisory,onSave,saving}) {
                             return locale.code === prompt.language
                         }).name}</Label>
                         <Input
-                            type="text"
+                            type="textarea"
                             name={`prompts[${index}].translation`}
                             placeholder={t('translation:translation')}
                             innerRef={register({required: true})}

--- a/client/src/containers/visits/VisitsManager.js
+++ b/client/src/containers/visits/VisitsManager.js
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { useParams, useHistory } from 'react-router-dom'
 import { useDispatch, useSelector, shallowEqual } from 'react-redux';
-import { deleteVisit, filterVisits, getVisits, saveVisit } from '../../actions/visitActions';
+import { cancelVisit, deleteVisit, filterVisits, getVisits, saveVisit } from '../../actions/visitActions';
 import VisitsList from '../../components/visits/VisitsList'
 import VisitDetail from '../../components/visits/VisitDetail'
 import VisitEditor from '../../components/visits/VisitEditor'
@@ -34,6 +34,9 @@ export default function VisitsManager({action}) {
 
     const history = useHistory()
     
+    const onCancel = (id) => {
+        dispatch(cancelVisit(id))
+    }
     const onDelete = (id) => {
         dispatch(deleteVisit(id))
     }
@@ -76,7 +79,6 @@ export default function VisitsManager({action}) {
         case 'show':
             return <VisitDetail visit={visit} />
         default:
-            return <VisitsList loading={loading} next={next} q={q} visits={visits}
-                onDelete={onDelete} onLoadMore={onLoadMore} onSearch={onSearch} />
+            return new VisitsList({loading,next,q,visits,onCancel,onDelete,onLoadMore,onSearch})
     }
 }

--- a/client/src/hooks/useAuthorized.js
+++ b/client/src/hooks/useAuthorized.js
@@ -1,0 +1,22 @@
+import { useCallback } from 'react'
+import { useSelector } from 'react-redux'
+
+/* Returns function which determines whether user is authorized based on certain tests specified in params
+ * @params roles: array of global roles authorized to perform an action
+ *         user: user authorized to perform the action (e.g. owner of the object of the action)
+ */
+export default function useAuthorized() {
+    const userId = useSelector(state => state.auth.user._id)
+    const global = useSelector(state => state.auth.user.roles)
+    const authorized = useCallback((params) => {
+        const {roles,user} = params
+        if (roles && roles.filter((r) => global.includes(r)).length > 0 ) {
+            return true
+        }
+        if (user && (user === userId || user._id === userId)) {
+            return true
+        }
+        return false
+    },[userId,global])
+    return authorized
+}

--- a/client/src/reducers/visitReducer.js
+++ b/client/src/reducers/visitReducer.js
@@ -5,6 +5,7 @@ import {
     ADD_VISIT,
     UPDATE_VISIT,
     SAVING_VISIT,
+    CANCEL_VISIT,
     DELETE_VISIT,
     VISITS_LOADING,
     LOGOUT_SUCCESS,
@@ -61,6 +62,7 @@ export default function visitReducer( state = initialState, action ) {
                 initNext: action.payload,
                 next: action.payload
             }
+        case CANCEL_VISIT:
         case DELETE_VISIT:
             return {
                 ...state,

--- a/features/advisories.feature
+++ b/features/advisories.feature
@@ -48,7 +48,7 @@ Feature: Manage advisories
         And I fill in "End time" with "1000A"
         And I fill in the "Districts" typeahead with "Other Range"
         And I fill in the "Contexts" typeahead with "check in"
-        And I fill in "English" with "Respect your environment please."
+        And I fill in the "English" textarea with "Respect your environment please."
         And I click the "Update advisory" button
         And I click "Detail" for advisory "Leave Only Footprints, Take Only Pictures"
         Then I should see "Label" defined as "Leave Only Footprints, Take Only Pictures"

--- a/features/step_definitions/general_steps.js
+++ b/features/step_definitions/general_steps.js
@@ -6,6 +6,7 @@ const {
     emailShouldBeSentTo,
     emailSubjectShouldBe,
     fillByLabel,
+    fillTextAreaByLabel,
     fillTypeaheadByLabel,
     formatTimeForDisplay,
     formatTimeForFill,
@@ -53,6 +54,10 @@ When('I change the language to {string}', async (language) => {
 
 When(/^I fill in "([^"]+)" with ("[^"]+"|today|tomorrow)$/, async (label, value) => {
     await fillByLabel(label,parseInput(value))
+})
+
+When('I fill in the {string} textarea with {string}', async (label,value) => {
+    await fillTextAreaByLabel(label,value)
 })
 
 When('I choose {string} for {string}', async (choice,label) => {

--- a/features/step_definitions/visits_steps.js
+++ b/features/step_definitions/visits_steps.js
@@ -79,7 +79,7 @@ When(
     /^I wait for my visit for (today|tomorrow) from "([^"]+)" to "([^"]+)" to disappear$/,
     async (when,from,to) => {
         const selector = `//div[contains(@class,'visits-list') and not(.${visitRowSelector(when,from,to)})]`
-        await waitFor(selector)
+        await waitFor(selector,{hidden: true})
     }
 )
 

--- a/features/support/actions.js
+++ b/features/support/actions.js
@@ -91,6 +91,15 @@ const fillElement = async (el, fill, clear = false ) => {
 	await el.click()
 	await el.type(fill)
 }
+const fillTextAreaByLabel = async (label, fill ) => {
+	const escapedText = escapeXpathString(label);
+	const selector = `//textarea[@name=(//label[contains(text(),${escapedText})][1]/@for)]`;
+	const page = scope.context.currentPage
+	const el = await page.$x(selector)
+	clearInput(el[0])
+	await el[0].click();
+	await el[0].type(fill);
+}
 const fillTypeaheadByLabel = async (label, fill, context) => {
 	const closeButton = await selectTypeaheadCloseByLabel(label, context)
 	if (closeButton) await closeButton.click()
@@ -332,6 +341,7 @@ module.exports = {
 	entitiesExist,
 	fillByLabel,
 	fillByPlaceholder,
+	fillTextAreaByLabel,
 	fillTypeaheadByLabel,
 	formatDateForFill,
 	formatDateForDisplay,

--- a/features/visits.feature
+++ b/features/visits.feature
@@ -169,11 +169,15 @@ Feature: Manage visits
         When I change the language to "Français"
         Then I should see an applicable advisory for "Leave No Trace" prompting "Respectez votre environnement"
 
-    Scenario: Remove visit
-        Given I am registered as "bmarshall@example.com"
+    Scenario Outline: Remove/Cancel visit
+        Given an admin user exists "Bob" "Marshall" "bmarshall@example.com"
+        And I logged in as "bmarshall@example.com"
         And I have registered a visit for today from "Adirondack Loj" to "Marcy Summit"
         And I have registered a visit for tomorrow from "Adirondack Loj" to "Algonquin Summit"
-        And I logged in as "bmarshall@example.com"
         When I visit the "home" page
-        And I click "Remove" for my visit for tomorrow from "Adirondack Loj" to "Algonquin Summit"
-        Then I should not see visit 2
+        And I click "<action>" for my visit for tomorrow from "Adirondack Loj" to "Algonquin Summit"
+        Then I wait for my visit for tomorrow from "Adirondack Loj" to "Algonquin Summit" to disappear
+        Examples:
+            |action|
+            |Remove|
+            |Cancel|

--- a/lib/routes/visits.js
+++ b/lib/routes/visits.js
@@ -1,18 +1,21 @@
 const express = require('express')
-const router = express.Router()
 const Visit = require('../../models/Visit')
 const paginate = require('../../lib/paginate')
 
-router.get(['/after/:afterId','/'], async (req, res) => {
-    try {
-        const {user} = req
-        const {q} = req.query
-        const pipeline = Visit.searchPipeline({user,q})
-        return paginate({req, res, model: Visit, pipeline})
-    }
-    catch(err) {
-        return res.status(500).json({code: 'ERROR'})
-    }
-})
+const visits = (cancelled) => {
+    const visits = express.Router()
+    visits.get(['/after/:afterId','/'], async (req, res) => {
+        try {
+            const {user} = req
+            const {q} = req.query
+            const pipeline = Visit.searchPipeline({cancelled,user,q})
+            return paginate({req, res, model: Visit, pipeline})
+        }
+        catch(err) {
+            return res.status(500).json({code: 'ERROR'})
+        }
+    })
+    return visits
+}
 
-module.exports = router
+module.exports = visits

--- a/middleware/auth.js
+++ b/middleware/auth.js
@@ -26,7 +26,7 @@ module.exports = ({isOptional,roles}={}) => async (req, res, next) => {
             return next()
         }
         else {
-            return res.status(401).json({code: E_AUTH_NEED_ROLE, roles})
+            return res.status(403).json({code: E_AUTH_NEED_ROLE, roles})
         }
     } catch(e) {
         return res.status(400).json({code: E_AUTH_INVALID_USER_TOKEN})

--- a/middleware/user.js
+++ b/middleware/user.js
@@ -15,5 +15,5 @@ module.exports = ({roles, self}={}) => asyncHandler( async (req, res, next) => {
     if (roles && roles.filter(r => req.authUser.roles.includes(r)).length > 0) {
         return next()
     }
-    return await res.status(401).json({code: E_UNAUTHORIZED})
+    return await res.status(403).json({code: E_UNAUTHORIZED})
 })

--- a/middleware/visit.js
+++ b/middleware/visit.js
@@ -4,14 +4,20 @@ const {
     E_AUTH_REQUIRED,
     E_UNAUTHORIZED
 } = require('../lib/errorCodes')
-const visit = () => asyncHandler( async (req, res, next) => {
+const visit = ({roles, self}={}) => asyncHandler( async (req, res, next) => {
     const visit = await Visit.findOne({_id: req.params.visitId})
-    if (!req.authUser) { return res.status(401).json({code: E_AUTH_REQUIRED}) }
-    if (!visit.user.equals(req.authUser._id)) {
-        return await res.status(401).json({code: E_UNAUTHORIZED})
-    }
     req.visit = visit
-    return next()
+    if (!req.authUser) { return res.status(401).json({code: E_AUTH_REQUIRED}) }
+    if (self && visit.user.equals(req.authUser._id)) {
+        return next()
+    }
+    if (roles && roles.filter(r => req.authUser.roles.includes(r)).length > 0) {
+        return next()
+    }
+    if (!self && !roles) {
+        return next()
+    }
+    return await res.status(403).json({code: E_UNAUTHORIZED})
 })
 
 module.exports = visit;

--- a/models/Place.js
+++ b/models/Place.js
@@ -70,8 +70,10 @@ PlaceSchema.statics.searchPipeline = ({location,q,startOn,type}) => {
                 // Originating at place
                 { $eq: ['$$originId','$origin'] },
                 // Intersecting with arrival
-               {$lte:["$startOn",startOn]},
-               {$lte:[startOn,"$endOn"]}
+                {$lte:["$startOn",startOn]},
+                {$lte:[startOn,"$endOn"]},
+                // Only include uncancelled
+                {$eq: [{$ifNull:['$cancelled',null]},null]}
             ]}}},
             // Count up visits, vehicles, and people
             {$group: {_id: null, parties: {$sum: 1}, parkedVehicles: {$sum: "$parkedVehicles"},

--- a/models/Visit.js
+++ b/models/Visit.js
@@ -43,6 +43,9 @@ const VisitSchema = new Schema({
     },
     checkedOut: {
         type: Date
+    },
+    cancelled: {
+        type: Date
     }
 },
 {

--- a/models/Visit.js
+++ b/models/Visit.js
@@ -94,9 +94,20 @@ VisitSchema.post('save', async function(visit) {
     await visit.populate('origin').populate('destinations').execPopulate()
 })
 
-VisitSchema.statics.searchPipeline = ({q,user}) => {
+VisitSchema.statics.searchPipeline = ({q,user,cancelled}) => {
     const c = []
     if (user) { c.push({$match: {user: ObjectId(user.id)}}) }
+    // If cancellation flag not specified, return cancelled and uncancelled
+    if (typeof cancelled !== 'undefined') {
+        // Return only cancelled
+        if (cancelled) {
+            c.push({$match:{cancelled:{$ne:null}}})
+        }
+        // Return only uncancelled
+        else {
+            c.push({$match:{cancelled: null}})
+        }
+    }
     c.push(
         {$lookup: {from: 'places',localField:'origin',foreignField:'_id',as:'origin'}},
         {$lookup: {from: 'places',localField:'destinations',foreignField:'_id',as:'destinations'}},

--- a/routes/api/users.js
+++ b/routes/api/users.js
@@ -25,7 +25,8 @@ const attrAccessible = (req) => {
     return attrAccessible
 }
 // Use visits routes scoped to the user
-router.use('/:userId/visits', auth(), user({self: true, roles:['admin']}), visits)
+router.use('/:userId/visits/cancelled', auth(), user({self: true, roles:['admin']}), visits(true))
+router.use('/:userId/visits', auth(), user({self: true, roles:['admin']}), visits(false))
 
 // @route POST api/users
 // @desc Register a new user

--- a/routes/api/visits.js
+++ b/routes/api/visits.js
@@ -69,6 +69,22 @@ router.post('/', auth(), async (req, res) => {
     }
 });
 
+// @route DELETE api/visits/cancel/:visitId
+// @desc Cancel a not-yet-cancelled visit
+// @access Private
+router.delete('/cancel/:visitId', auth(), visit(), async (req,res) => {
+    if (req.visit.cancelled) {
+        return res.status(404).json({})
+    }
+    try {
+        req.visit.cancelled = Date.now()
+        return res.status(200).json(await req.visit.save())
+    }
+    catch(err) {
+        throw err
+    }
+})
+
 // @route DELETE api/visits
 // @desc Delete an existing visit
 // @access Private

--- a/routes/api/visits.js
+++ b/routes/api/visits.js
@@ -69,12 +69,12 @@ router.post('/', auth(), async (req, res) => {
     }
 });
 
-// @route DELETE api/visits/cancel/:visitId
+// @route POST api/visits/cancelled/:visitId
 // @desc Cancel a not-yet-cancelled visit
 // @access Private
-router.delete('/cancel/:visitId', auth(), visit(), async (req,res) => {
+router.post('/cancelled/:visitId', auth(), visit(), async (req,res) => {
     if (req.visit.cancelled) {
-        return res.status(404).json({})
+        return res.status(409).json({})
     }
     try {
         req.visit.cancelled = Date.now()

--- a/routes/api/visits.js
+++ b/routes/api/visits.js
@@ -3,6 +3,7 @@ const router = express.Router();
 const auth = require('../../middleware/auth');
 const Visit = require('../../models/Visit');
 const visit = require('../../middleware/visit')
+const visits = require('../../lib/routes/visits')
 const handleValidationError = require('../../lib/handleValidationError')
 const attrAccessible = (req) => {
     const attrAccessible = req.visit ? req.visit : {}
@@ -16,24 +17,10 @@ const attrAccessible = (req) => {
 }
 const advisoryContext = require('../../middleware/advisoryContext')
 
-// @route GET api/visits/:visitId
-// @desc Load a single visit
-// @access Private
-router.get('/:visitId', auth(), visit(), async (req, res) => {
-    return res.status(200).json(req.visit)
-})
-
-// @route GET api/visits/:visitId/applicableVisits
-// @desc Load advisories applicable to a visit
-// @access Private
-router.get('/:visitId/applicableAdvisories/:advisoryContext', auth(), visit(), advisoryContext(true), async (req, res) => {
-    return res.status(200).json(await req.visit.applicableAdvisories(req.advisoryContext))
-})
-
 // @route PUT api/visits/:visitId
 // @desc Update an existing visit
 // @access Private
-router.put('/:visitId', auth(), visit(), async (req, res) => {
+router.put('/:visitId', auth(), visit({roles:['admin'],self:true}), async (req, res) => {
     attrAccessible(req)
     try {
         return res.status(200).json(await req.visit.save())
@@ -45,6 +32,22 @@ router.put('/:visitId', auth(), visit(), async (req, res) => {
         else {
             throw err
         }
+    }
+})
+
+// @route POST api/visits/cancelled/:visitId
+// @desc Cancel a not-yet-cancelled visit
+// @access Private
+router.post('/cancelled/:visitId', auth(), visit({roles:['admin'],self: true}), async (req,res) => {
+    if (req.visit.cancelled) {
+        return res.status(409).json({})
+    }
+    try {
+        req.visit.cancelled = Date.now()
+        return res.status(200).json(await req.visit.save())
+    }
+    catch(err) {
+        throw err
     }
 })
 
@@ -69,26 +72,10 @@ router.post('/', auth(), async (req, res) => {
     }
 });
 
-// @route POST api/visits/cancelled/:visitId
-// @desc Cancel a not-yet-cancelled visit
-// @access Private
-router.post('/cancelled/:visitId', auth(), visit(), async (req,res) => {
-    if (req.visit.cancelled) {
-        return res.status(409).json({})
-    }
-    try {
-        req.visit.cancelled = Date.now()
-        return res.status(200).json(await req.visit.save())
-    }
-    catch(err) {
-        throw err
-    }
-})
-
 // @route DELETE api/visits
 // @desc Delete an existing visit
 // @access Private
-router.delete('/:visitId', auth(), visit(), async (req, res) => {
+router.delete('/:visitId', auth(), visit({roles:['admin'],self:true}), async (req, res) => {
     try {
         await req.visit.deleteOne()
         return res.json({success: true})
@@ -100,9 +87,27 @@ router.delete('/:visitId', auth(), visit(), async (req, res) => {
     }
 });
 
+// @route GET api/visits/cancelled
+// @desc Get cancelled visits
+// @access Private
+router.use('/cancelled', auth({roles:['admin']}), visits(true))
+
+// @route GET api/visits/:visitId
+// @desc Load a single visit
+// @access Private
+router.get('/:visitId', auth(), visit({roles:['admin'],self:true}), async (req, res) => {
+    return res.status(200).json(req.visit)
+})
+
+// @route GET api/visits/:visitId/applicableVisits
+// @desc Load advisories applicable to a visit
+// @access Private
+router.get('/:visitId/applicableAdvisories/:advisoryContext', auth(), visit({roles:['admin'],self:true}), advisoryContext(true), async (req, res) => {
+    return res.status(200).json(await req.visit.applicableAdvisories(req.advisoryContext))
+})
 // @route GET api/visits
 // @desc Get all visits
 // @access Private
-router.use('/', auth({roles:['admin']}), require('../../lib/routes/visits'))
+router.use('/', auth({roles:['admin']}), visits(false))
 
 module.exports = router;

--- a/test/api/places.js
+++ b/test/api/places.js
@@ -50,6 +50,14 @@ describe('/api/places',() => {
                 groupSize: 4,
                 startOn: justBefore
             })
+            await factory.create('visit',{
+                origin: places.origin._id,
+                durationNights: 0,
+                parkedVehicles: 2,
+                groupSize: 4,
+                startOn: justBefore,
+                cancelled: Date.now()
+            })
             justAfter = new Date(startOn)
             justAfter.setHours(justAfter.getHours()+1)
             await factory.create('visit',{

--- a/test/api/users.js
+++ b/test/api/users.js
@@ -251,7 +251,7 @@ describe('/api/users', () => {
             const auth = await withAuth()
             const user = await factory.create('user')
             const res = await action(auth,{},user)
-            res.should.have.status(401)
+            res.should.have.status(403)
             res.body.should.have.a.property('code').eql('UNAUTHORIZED')
         })
         it('should allow an admin user who is not the owner', async () => {
@@ -288,7 +288,7 @@ describe('/api/users', () => {
             const auth = await withAuth()
             const user = await factory.create('user')
             const res = await action(user,auth)
-            res.should.have.status(401)
+            res.should.have.status(403)
         })
         it('should deny for unauthenticated user', async () => {
             const user = await factory.create('user')

--- a/test/api/visits.js
+++ b/test/api/visits.js
@@ -156,9 +156,9 @@ describe('/api/visits', () => {
             return errorNoToken(res)
         })
     })
-    describe('DELETE /api/visits/cancel/:visitId', () => {
+    describe('POST /api/visits/cancelled/:visitId', () => {
         const action = async (visit,auth) => {
-            const req = chai.request(server).delete(`/api/visits/cancel/${visit._id}`)
+            const req = chai.request(server).post(`/api/visits/cancelled/${visit._id}`)
             if (auth) { req.set('x-auth-token',auth.body.token) }
             return req
         }
@@ -174,7 +174,7 @@ describe('/api/visits', () => {
             const auth = await withAuth()
             const visit = await factory.create('visit',{user: auth.body.user._id, cancelled: Date.now()})
             res = await action(visit,auth)
-            res.should.have.status(404)
+            res.should.have.status(409)
         })
         it('should deny with nonowner credentials', async () => {
             const auth = await withAuth()

--- a/test/support/middlewareErrors.js
+++ b/test/support/middlewareErrors.js
@@ -1,5 +1,5 @@
 module.exports.errorMustHaveRoles = (res,roles) => {
-    res.should.have.status(401)
+    res.should.have.status(403)
     res.body.should.be.an('object')
     res.body.should.have.a.property('code').eq('AUTH_NEED_ROLE')
     res.body.should.have.a.property('roles').has.members(roles)


### PR DESCRIPTION
Support cancelling visits as alternative to deleting them.  If we are to collect good data for predicting crowds at trailheads, we need to capture aborted trips as well as completed ones.  Generally, removing visit records should be prohibited in favor of cancelling them.  This implementation provides for cancellation with the following expectations:

1. Cancelled visits should not appear in crowding information when a person is selecting an origin for a visit.
2. Cancelled visits should not appear in the visits listing.
3. The Remove button will only be allowed for global "admin" users